### PR TITLE
Loosen dependency on react-rails version

### DIFF
--- a/react-router-rails.gemspec
+++ b/react-router-rails.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
 
   spec.add_dependency 'rails', '>= 3.1'
-  spec.add_dependency 'react-rails', '~> 1.4.0'
+  spec.add_dependency 'react-rails', '~> 1.4'
 end


### PR DESCRIPTION
React-rails 1.5.0 was released, but it cannot be used with this gem because of too strict version dependency. This fix allows to use 1.5.0 version and all versions < 2.0.0
