### PR TITLE
ActionDispatch::Reloader no longer has .to_prepare method in Ruby 5.1

### DIFF
--- a/lib/react/router/rails/railtie.rb
+++ b/lib/react/router/rails/railtie.rb
@@ -35,7 +35,9 @@ module React
 
           do_setup.call
 
-          ActionDispatch::Reloader.to_prepare(&do_setup)
+          reloader = defined?(ActiveSupport::Reloader) ? ActiveSupport::Reloader : ActionDispatch::Reloader
+
+          reloader.to_prepare(&do_setup)
         end
       end
     end


### PR DESCRIPTION
Check to see which Reloader class we should use before calling it 